### PR TITLE
system_bus: be consistent and always call it 'System Bus'

### DIFF
--- a/dm1_registers.xml
+++ b/dm1_registers.xml
@@ -120,9 +120,9 @@
         <field name="halt1023:992" bits="31" access="R" reset="0" />
     </register>
 
-    <!-- =============== bus mastering =============== -->
+    <!-- =============== system bus mastering =============== -->
 
-    <register name="Bus Access Control" short="sbcs" address="0x03">
+    <register name="System Bus Access Control" short="sbcs" address="0x03">
         <field name="0" bits="31:20" access="R" reset="0" />
         <field name="sbaccess" bits="19:17" access="R/W" reset="2">
             Select the access size to use for system bus accesses triggered by
@@ -138,23 +138,27 @@
 
 	    4: 128-bit
 
-            If an unsupported bus access size is written here, the DM may not
+            If an unsupported system bus access size is written here,
+	    the DM may not
             perform the access, or may perform the access with any access size
         </field>
-        <field name="autoincrement" bits="16" access="R/W" reset="0">
-            When 1, the internal address value (used by the bus master) is
-            incremented by the access size (in bytes) selected in \Fsbaccess after
-            every bus access.
+        <field name="sbautoincrement" bits="16" access="R/W" reset="0">
+          When 1, the internal address value (used by the system bus master)
+	  is
+          incremented by the access size (in bytes) selected in \Fsbaccess after
+          every system bus access.
         </field>
-        <field name="autoread" bits="15" access="R/W" reset="0">
-            When 1, every write to \Rsbaddresszero automatically triggers a bus
-            read at the new address.
+        <field name="sbautoread" bits="15" access="R/W" reset="0">
+          When 1, every write to \Rsbaddresszero automatically triggers a
+	  system bus
+          read at the new address.
         </field>
         <field name="sberror" bits="14:12" access="R/W0" reset="0">
-            When the debug bus master causes a bus error, this field gets set.
-            It remains set until 0 is written to any bit in this field. Until
-            that happens, the bus master is busy and no more accesses can be
-            initiated.
+          When the debug module's system bus
+	  master causes a bus error, this field gets set.
+          It remains set until 0 is written to any bit in this field. Until
+          that happens, the system bus master is busy and no more accesses can be
+            initiated by the debug module.
 
             0: There was no bus error.
 
@@ -164,37 +168,39 @@
 
             3: There was some other error (eg. alignment).
 
-            4: The bus master was busy when a one of the $|sbaddress|$ or
+            4: The system bus master was busy when a one of the $|sbaddress|$ or
             $|sbdata|$ registers was written.
         </field>
-        <field name="abussize" bits="11:5" access="R" reset="Preset">
-            Width of the address bus in bits. (0 indicates there is no bus
+        <field name="sbasize" bits="11:5" access="R" reset="Preset">
+            Width of system bus addresses in bits. (0 indicates there is no bus
             access support.)
         </field>
         <field name="sbaccess128" bits="4" access="R" reset="Preset">
-            1 when 128-bit bus accesses are supported.
+            1 when 128-bit system bus accesses are supported.
         </field>
         <field name="sbaccess64" bits="3" access="R" reset="Preset">
-            1 when 64-bit bus accesses are supported.
+            1 when 64-bit system bus accesses are supported.
         </field>
         <field name="sbaccess32" bits="2" access="R" reset="Preset">
-            1 when 32-bit bus accesses are supported.
+            1 when 32-bit system bus accesses are supported.
         </field>
         <field name="sbaccess16" bits="1" access="R" reset="Preset">
-            1 when 16-bit bus accesses are supported.
+            1 when 16-bit system bus accesses are supported.
         </field>
         <field name="sbaccess8" bits="0" access="R" reset="Preset">
-            1 when 8-bit bus accesses are supported.
+            1 when 8-bit system bus accesses are supported.
         </field>
     </register>
 
     <register name="System Bus Address 31:0" short="sbaddress0" address="0x04">
-        If \Fabussize is 0, then this register is not present.
+        If \Fsbasize is 0, then this register is not present.
 
-        When the bus master is busy, writes to this register will return error
+        When the syste bus master is busy,
+	writes to this register will return error
         and \Fsberror is set.
 
-        If \Fsberror is 0 and \Fautoread is set then the bus master will start
+        If \Fsberror is 0 and \Fsbautoread is set then the system bus
+	master will start
         to read after updating the address from \Faddress. The access size is
         controlled by \Fsbaccess in \Rdmcontrol.
 
@@ -211,7 +217,7 @@
     </register>
 
     <register name="System Bus Address 91:61" short="sbaddress2" address="0x06">
-        If \Fabussize is less than 65, then this register is not present.
+        If \Fsbasize is less than 65, then this register is not present.
 
         <field name="busy" bits="31" access="R" reset="0">
             The same as \Fbusy in \Rsbaddresszero.
@@ -241,7 +247,7 @@
         since the last time this register was read, then set \Fsberror, return
         error, and don't do anything else.
         2. "Return" the data.
-        3. If \Fautoread is set, start another bus read.
+        3. If \Fsbautoread is set, start another system bus read.
 
         <field name="data" bits="31:0" access="R/W" reset="0">
             Accesses bits 31:0 of the internal data.

--- a/riscv-debug-spec.tex
+++ b/riscv-debug-spec.tex
@@ -229,7 +229,8 @@ The debug interface described out here supports the following features:
        resume.
    \item Memory is accessed through the core, so the debugger will see the same
        thing that the code that is executing sees.
-   \item Optionally, a bus master can be implemented to allow memory access
+     \item Optionally, a system bus master can be implemented to
+       allow memory access
        without involving any hart.
    \item Debugging can be supported over multiple transports.
    \item Code can be downloaded efficiently.
@@ -331,7 +332,7 @@ Bus. The details are left to the system designer.
 
 The DMI uses between TODO and 32 address bits.  It supports read and write
 operations, which may return an error. (Errors are only used by the optional
-Bus Access and Serial Port blocks.) TODO: The bottom of the address space is
+System Bus Access and Serial Port blocks.) TODO: The bottom of the address space is
 used for the DM. Extra space can be used for custom debug devices, other cores,
 additional DMs, etc.
 
@@ -437,14 +438,15 @@ equivalent of printf debugging, to provide a simple CLI without requiring any
 extra peripherals, or more generally to emulate devices that aren't present.
 All these uses require software support, and are not further specified here.
 
-\subsection{Bus Access}
+\subsection{Sytem Bus Access}
 
 In a minimal configuration a debugger can access the system bus by having a
 RISC-V hart perform the accesses it requires. Optionally a Bus Access block may
-be implemented. Because the Bus Access block performs accesses directly from
-the DM, it only uses physical addresses.
+be implemented. Because the System Bus Access block performs accesses directly
+from the DM, it only uses physical addresses.
 
-Implementing a Bus Access block has several benefits. First, it is possible to
+Implementing a System Bus Access block has several benefits.
+First, it is possible to
 access memory in a running system with minimal impact.  Second, it may improve
 performance when downloading programs. (There is only a benefit if JTAG TCK is a
 significant fraction of the RISC-V hart's clock speed.)  Third, it may provide
@@ -457,7 +459,8 @@ systems should use the same memory map for each hart. That means that a given
 address maps to the same device no matter which hart performs the access.
 (Different harts may not all have permission to access the same devices.) If
 different harts do have unique memory maps then the system should provide
-access to all devices using the Bus Access block. This will make implementing,
+access to all devices using the Sytem Bus Access block.
+This will make implementing,
 configuring, and using a debugger more complex so should be avoided if
 possible.
 
@@ -881,7 +884,7 @@ registers can be accessed by moving their value into/out of GPRs.
 
 \subsection{Reading Memory}
 
-\subsubsection{Using Bus Access}
+\subsubsection{Using System Bus Access}
 
 \subsubsection{Using Program Buffer}
 


### PR DESCRIPTION
Even if some dislike the implications of the name, we should be consistent and clear in the spec. And it's easier to find-and-replace if we choose a different name.
