### PR TITLE
Typos/errors in abstract command

### DIFF
--- a/abstract_commands.xml
+++ b/abstract_commands.xml
@@ -7,7 +7,7 @@
         \item Copy data from the register specified by \Fregno into {\tt data}, if \Fwrite is clear.
         \item Copy data from {\tt data} into the register specified by \Fregno, if \Fwrite is set.
         \item Execute the Program Buffer, if \Fpostexec is set.
-        \item Resume the hart, if \Fpostresume is set. If the hart is already 
+        \item Resume the hart, if \Fpostresume is set. If the hart is already
         running and \Fprehalt is not set, the entire command fails.
         \end{steps}
 

--- a/abstract_commands.xml
+++ b/abstract_commands.xml
@@ -2,13 +2,13 @@
     <register name="Access Register">
         \begin{steps}{Perform the following sequence of operations:}
         \item Halt the hart, if \Fprehalt is set. If the hart is already
-            handled, the entire command fails.
+            halted, the entire command fails.
         \item Execute the Program Buffer, if \Fpreexec is set.
         \item Copy data from the register specified by \Fregno into {\tt data}, if \Fwrite is clear.
         \item Copy data from {\tt data} into the register specified by \Fregno, if \Fwrite is set.
         \item Execute the Program Buffer, if \Fpostexec is set.
-        \item Resume the hart, if \Fpostresume is set. If the hart is already
-            running, the entire command fails.
+        \item Resume the hart, if \Fpostresume is set. If the hart is already 
+        running and \Fprehalt is not set, the entire command fails.
         \end{steps}
 
         If any of these operations fail, \Fcmderr is set and none of the

--- a/abstract_commands.xml
+++ b/abstract_commands.xml
@@ -8,7 +8,7 @@
         \item Copy data from {\tt data} into the register specified by \Fregno, if \Fwrite is set.
         \item Execute the Program Buffer, if \Fpostexec is set.
         \item Resume the hart, if \Fpostresume is set. If the hart is already
-        running and \Fprehalt is not set, the entire command fails.
+            running and \Fprehalt is not set, the entire command fails.
         \end{steps}
 
         If any of these operations fail, \Fcmderr is set and none of the


### PR DESCRIPTION
I fixed a typo and modified the error case for postresume because it doesn't make sense. The cases are:

-> Hart is running, but you've set both prehalt and postresume. That seems like a valid use case.
-> Hart was halted, but you're using this mechanism to get it out of halt. 
-> Hart is running, but you didn't set prehalt and you did set postresume. This seems like the only error case.