### PR TITLE
Clarify "arguments" to commands

### DIFF
--- a/abstract_commands.xml
+++ b/abstract_commands.xml
@@ -4,8 +4,10 @@
         \item Halt the hart, if \Fprehalt is set. If the hart is already
             handled, the entire command fails.
         \item Execute the Program Buffer, if \Fpreexec is set.
-        \item Copy data from the register specified by \Fregno into {\tt data}, if \Fwrite is clear.
-        \item Copy data from {\tt data} into the register specified by \Fregno, if \Fwrite is set.
+        \item Copy data from the register specified by \Fregno into the {\tt arg0} region of
+            {\tt data}, if \Fwrite is clear.
+        \item Copy data from the {\tt arg0} region of {\tt data} into the register specified
+            by \Fregno, if \Fwrite is set.
         \item Execute the Program Buffer, if \Fpostexec is set.
         \item Resume the hart, if \Fpostresume is set. If the hart is already
             running, the entire command fails.

--- a/riscv-debug-spec.tex
+++ b/riscv-debug-spec.tex
@@ -415,13 +415,13 @@ clock cycles will be a more typical latency.)
 
 \subsection{Abstract Commands} \label{abstractcommands}
 
-A debugger can execute abstract commands by writing the command to \Rcommand.
-If a command takes an argument, the debugger must write it to the {\tt data}
-registers before writing to \Rcommand. If a command returns a results, it is
+A debugger can execute an abstract command by writing the command to \Rcommand.
+If the command takes arguments, the debugger must write them to the {\tt data}
+registers before writing to \Rcommand. If a command returns results, they are
 placed in the {\tt data} registers when the command is complete. Which {\tt
-data} registers are used is described in Table~\ref{tab:datareg}. Depending on
-the implementation, it may be possible to perform abstract commands even when
-the hart is not halted.
+data} registers are used for the arguments is described in Table~\ref{tab:datareg}. 
+Depending on the implementation, it may be possible to perform abstract commands 
+even when the hart is not halted.
 
 \begin{table}[htp]
     \centering

--- a/riscv-debug-spec.tex
+++ b/riscv-debug-spec.tex
@@ -418,8 +418,8 @@ clock cycles will be a more typical latency.)
 A debugger can execute an abstract command by writing the command to \Rcommand.
 If the command takes arguments, the debugger must write them to the {\tt data}
 registers before writing to \Rcommand. If a command returns results, they are
-placed in the {\tt data} registers when the command is complete. Which {\tt
-data} registers are used for the arguments is described in Table~\ref{tab:datareg}. 
+placed in the {\tt data} registers when the command is complete. Which {\tt data}
+registers are used for the arguments is described in Table~\ref{tab:datareg}. 
 Depending on the implementation, it may be possible to perform abstract commands 
 even when the hart is not halted.
 


### PR DESCRIPTION
I was confused about arg0 and arg1. Clarifying.