### PR TITLE
Allow size 4 for the program buffer

### DIFF
--- a/dm1_registers.xml
+++ b/dm1_registers.xml
@@ -387,7 +387,7 @@
     <register name="Access Status and Control" short="accesscs" address="0x15">
         <field name="0" bits="31:4" access="R" reset="0" />
         <field name="progsize" bits="3:0" access="R" reset="Preset">
-            Size of the Program Buffer, in 32-bit words. Valid sizes are 0, 1,
+            Size of the Program Buffer, in 32-bit words. Valid sizes are 0, 1, 4,
             and 8.
 
             A debugger must not access any Instruction Buffer locations that


### PR DESCRIPTION
Why is Program Buffer only allowed to be size 8?

In our previous implementation, for an XLEN=32 design, we only needed 7 words to implement the desired functionality for both program buffer and data transfer. With the latest "quick access" proposal we'll need 3 words for data. Is it possible to do what we need with only 4 words? (or 5 if we must implement ebreak at the end)?