### PR TITLE
Make comments on program buffer size match the address map.

### DIFF
--- a/dm1_registers.xml
+++ b/dm1_registers.xml
@@ -502,11 +502,14 @@
     <register name="Access Status and Control" short="accesscs" address="0x1f">
         <field name="0" bits="31:4" access="R" reset="0" />
         <field name="progsize" bits="3:0" access="R" reset="Preset">
-            Size of the Program Buffer, in 32-bit words. Valid sizes are 0, 1, 4,
-            and 8.
+            Size of the Program Buffer, in 32-bit words. Valid sizes are 0 - 12
 
             A debugger must not access any Instruction Buffer locations that
             fall outside the range specified here.
+
+	    TODO: Explain what can be done with each size of the buffer, to suggest
+	    why you would want more or less words.
+
         </field>
     </register>
 

--- a/dm1_registers.xml
+++ b/dm1_registers.xml
@@ -502,7 +502,7 @@
     <register name="Access Status and Control" short="accesscs" address="0x1f">
         <field name="0" bits="31:4" access="R" reset="0" />
         <field name="progsize" bits="3:0" access="R" reset="Preset">
-            Size of the Program Buffer, in 32-bit words. Valid sizes are 0 - 12
+            Size of the Program Buffer, in 32-bit words. Valid sizes are 0 - 12.
 
             A debugger must not access any Instruction Buffer locations that
             fall outside the range specified here.


### PR DESCRIPTION
Size of program buffer was bumped to 12 words, but we left the limited size in the text.

I think rather than saying what the legal sizes are, we should just say what you get with each size (e.g. 4 words allows quick access to registers, 8 to memory, 10 to CSRs). I just made those numbers up though. 