### PR TITLE
jtag: More clarifications

### DIFF
--- a/jtag_registers.xml
+++ b/jtag_registers.xml
@@ -49,12 +49,10 @@
         </field>
         <field name="0" bits="15" access="R" reset="0" />
         <field name="idle" bits="14:12" access="R" reset="Preset">
-            This is a hint to the debugger of the minimum number of cycles
-            a debugger should spend in
+            This is the minimum number of cycles a debugger should spend in
             Run-Test/Idle after every DMI scan to avoid a 'busy'
-            return code (\Fdmistat of 3). This field may
-            be incorrect and a debugger must still function properly
-            by checking \Fdmistat when necessary.
+            return code (\Fdmistat of 3). A debugger must still
+            check \Fdmistat when necessary.
 
             0: It is not necessary to enter Run-Test/Idle at all.
 
@@ -63,13 +61,6 @@
             2: Enter Run-Test/Idle and stay there for 1 cycle before leaving.
 
             And so on.
-
-            \begin{commentary}
-            TODO: How useful is this? The debugger can quickly find this out
-            by reading DMINFO a few times until it figures out the value.
-            It is likely to be just a guess most of the time.
-            \end{commentary
-
         </field>
         <field name="dmistat" bits="11:10" access="R" reset="0">
             0: No error.

--- a/riscv-debug-spec.tex
+++ b/riscv-debug-spec.tex
@@ -796,17 +796,13 @@ All debug adapter pins other than GND should be current-limited to 20mA.
 
 \subsection{JTAG Registers}
 
-%MAW -- is it required that the DTM be the only functionality of the TAP?
-% Is it expected to be daisy-chained with a tap which drives scan
-% functionality, etc? Or is it allowed to combine into a single tap?
-% if the latter, is the 5-bit IR a minimum or hard requirement?
-
-JTAG DTMs should use a 5-bit JTAG IR. When the TAP is reset, IR must default to
+JTAG TAPs used as a DTM must have an IR of at least 5 bits.
+When the TAP is reset, IR must default to
 00001, selecting the IDCODE instruction. A full list of JTAG registers along
 with their encoding is in Table~\ref{table:jtag_registers}. The only regular
-JTAG registers a debugger might use are BYPASS and IDCODE, but the JTAG
-standard recommends a lot of other instructions so we leave IR space for them.
-If they are not implemented, then they must select the BYPASS register.
+JTAG registers a debugger might use are BYPASS and IDCODE, but this
+specification leaves IR space for many other standard JTAG instructions.
+Unimplemented instructions must select the BYPASS register.
 
 \input{jtag_registers.tex}
 


### PR DESCRIPTION
-IR width of 5 is only a minimum
-Remove commentary about \idle.

This is my followup to your comments on  #19 