### PR TITLE
SystemBus: Clean up some formatting and error specification notes.

### DIFF
--- a/dm1_registers.xml
+++ b/dm1_registers.xml
@@ -195,8 +195,11 @@
 
             3: There was some other error (eg. alignment).
 
-            4: The system bus master was busy when a one of the {\tt sbaddress} or
-            {\tt sbdata} registers was written.
+            4: The system bus master was busy when a one of the
+            {\tt sbaddress} or {\tt sbdata} registers was written,
+            or the {\tt sbdata} register was read when it had
+            stale data.
+
         </field>
         <field name="sbasize" bits="11:5" access="R" reset="Preset">
             Width of system bus addresses in bits. (0 indicates there is no bus
@@ -264,20 +267,27 @@
         If \Fsberror isn't 0 then accesses return error, and don't do anything
         else.
 
-        If the bus master is busy then accesses set \Fsberror, return error,
+        Writes to this register:
+
+        1. If the bus master is busy then accesses set \Fsberror, return error,
         and don't do anything else.
 
-        Writes to this register:
-        1. Update internal data.
-        2. Start a bus write of the internal data to the internal address.
-        3. If \Fsbautoincrement is set, increment the internal address.
+        2. Update internal data.
+
+        3. Start a bus write of the internal data to the internal address.
+
+        4. If \Fsbautoincrement is set, increment the internal address.
 
         Reads to this register:
+
         1. If bits 31:0 of the internal data register haven't been updated
         since the last time this register was read, then set \Fsberror, return
         error, and don't do anything else.
-        2. "Return" the data.
+
+        2. ``Return'' the data.
+
         3. If \Fsbautoincrement is set, increment the internal address.
+
         4. If \Fsbautoread is set, start another system bus read.
 
         <field name="data" bits="31:0" access="R/W" reset="0">


### PR DESCRIPTION
One of the error cases (SB read underflow) seemed incorrectly described. Also added some formatting fixes.