### PR TITLE
Clarify that the halt state of all harts is maintained through reset

### DIFF
--- a/riscv-debug-spec.tex
+++ b/riscv-debug-spec.tex
@@ -400,7 +400,8 @@ Transport Modules. The purpose of this feature is to allow debugging
 programs from the first instruction executed, so exactly what is affected
 by this reset is implementation dependent. Debug Module's own state and registers are
 generally reset at power-up and if and only if
-\Fdmactive in \Rdmcontrol is 0.
+\Fdmactive in \Rdmcontrol is 0. This means that the halt state of all harts is
+maintained provided that \Fdmactive is 1, although trigger CSRs may be cleared.
 
 \subsection{Selecting Harts} \label{selectingharts}
 


### PR DESCRIPTION
This addresses the question from me on the mailing list and in today's meeting. There were a few similar questions, so it seems worthwhile to make things more explicit.