### PR TITLE
Add explicit type field to Abstract Command.

### DIFF
--- a/abstract_commands.xml
+++ b/abstract_commands.xml
@@ -20,7 +20,10 @@
         hart is halted. Accessing other registers, or accessing registers while
         the hart is running, is optional.
 
-        <field name="0" bits="31:22" />
+        <field name="type" bits="31:24">
+            This is 0 to indicate Access Register Command.
+        </field>
+        <field name="0" bits="23:22" />
         <field name="size" bits="21:19">
             2: Access the lowest 32 bits of the register.
 
@@ -68,7 +71,9 @@
 
         Implementing this command is optional.
 
-        <field name="1" bits="31:24" />
+        <field name="type" bits="31:24">
+            This is 1 to indicate Quick Access command.
+        </field>
         <field name="0" bits="23:0" />
     </register>
 </registers>

--- a/dm1_registers.xml
+++ b/dm1_registers.xml
@@ -428,7 +428,14 @@
             previous one succeeding) passed.
         \end{commentary}
 
-        <field name="command" bits="31:0" access="W" reset="0" />
+        <field name="type"    bits="31:24" access="W" reset="0">
+            The type determines the overall functionality of this
+            abstract command.
+	</field>
+        <field name="control" bits="23:0" access="W" reset="0" >
+            This field is interpreted in a command-specific manner,
+            described for each abstract command.
+	</field>
     </register>
 
     <register name="Abstract Data 0" short="data0" address="0x10">


### PR DESCRIPTION
This seems important for an implementation to be able to decide what abstract command you're talking about... if you have another encoding in mind, let me know. 
